### PR TITLE
Fix license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Make sure you have installed [docker](https://docs.docker.com/installation/) and [compose](https://docs.docker.com/compose/install/).
 
-Go get a free Pro Starter License from [Tyk.io](https://tyk.io/tyk-professional-licenses/) and add it to the `license_key` field in the `tyk_analytics.conf` file and save it:
+Go get a free On-Premises License from [Tyk.io](https://tyk.io/product/tyk-on-premises-free-edition/) and add it to the `license_key` field in the `tyk_analytics.conf` file and save it:
 
 	{
 	    ...
@@ -13,7 +13,7 @@ Go get a free Pro Starter License from [Tyk.io](https://tyk.io/tyk-professional-
 	}
 
 Launch the stack:
-    
+
     docker-compose up -d
 
 Setup your organization/user and portal:
@@ -63,7 +63,7 @@ An additional requirement is to provide a directory for the plugin bundles:
         environment:
             - TYKVERSION=-python
 ```
-	
+
 
 Remember to modify your `tyk.conf` to include the required global parameters, essentially:
 


### PR DESCRIPTION
The link to obtain a Tyk license is currently broken in the readme. This PR fixes the link. It also cleans up some extraneous whitespace in the readme.