### PR TITLE
bug: limit mongo & redis to known working versions

### DIFF
--- a/docker-compose-pre-1.9.yml
+++ b/docker-compose-pre-1.9.yml
@@ -31,9 +31,9 @@ tyk_dashboard:
     environment:
         - DNSDOCK_NAME=tyk_dashboard
 tyk_redis:
-    image: redis:latest
+    image: redis:3.2
     hostname: redis
 tyk_mongo:
-    image: mongo:latest
+    image: mongo:3.0
     command: ["mongod", "--smallfiles"]
     hostname: mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
     tyk_redis:
-        image: redis:latest
+        image: redis:3.2
         hostname: redis
         ports:
             - "6379:6379"
@@ -11,7 +11,7 @@ services:
                 aliases:
                     - redis
     tyk_mongo:
-        image: mongo:latest
+        image: mongo:3.0
         command: ["mongod", "--smallfiles"]
         hostname: mongo
         ports:


### PR DESCRIPTION
Backwards incompatible changes in newer versions of mongo which were
being picked up by `latest` tag.

This commit limits mongo version to `3.0` and redis to `3.2`.

e.g. newer mongo version auto-binds to localhost, rather than public
network, meaning that mongo not available to any other container.